### PR TITLE
feature: `#[init]` macro to automatically define a safe library initialization function

### DIFF
--- a/RustLink/Tests/NativeArgs.wlt
+++ b/RustLink/Tests/NativeArgs.wlt
@@ -136,6 +136,23 @@ Test[
 	11
 ]
 
+(*---------*)
+(* Panics  *)
+(*---------*)
+
+Test[
+	LibraryFunctionLoad[
+		"liblibrary_tests",
+		"test_panic",
+		{},
+		"Void"
+	][]
+	,
+	LibraryFunctionError["LIBRARY_USER_ERROR", 1002]
+	,
+	{LibraryFunction::rterr}
+]
+
 (*----------------*)
 (* NumericArray's *)
 (*----------------*)

--- a/wolfram-library-link/Cargo.toml
+++ b/wolfram-library-link/Cargo.toml
@@ -6,6 +6,8 @@ license = "MIT OR Apache-2.0"
 edition = "2021"
 
 [dependencies]
+wll-proc-macros                = { path = "./wll-proc-macros" }
+
 wolfram-library-link-sys       = { path = "../wolfram-library-link-sys" }
 
 wstp         = { git = "https://github.com/WolframResearch/wstp-rs" }

--- a/wolfram-library-link/examples/exprs/managed.rs
+++ b/wolfram-library-link/examples/exprs/managed.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, os::raw::c_int, sync::Mutex};
+use std::{collections::HashMap, sync::Mutex};
 
 use once_cell::sync::Lazy;
 
@@ -6,7 +6,6 @@ use wolfram_library_link::{
     self as wll,
     expr::{Expr, ExprKind, Symbol},
     managed::{Id, ManagedExpressionEvent},
-    sys,
 };
 
 wll::export_wstp![
@@ -26,20 +25,12 @@ struct MyObject {
     value: String,
 }
 
-#[no_mangle]
-pub unsafe extern "C" fn WolframLibrary_initialize(
-    lib: sys::WolframLibraryData,
-) -> c_int {
-    if let Err(()) = wll::initialize(lib) {
-        return 1;
-    }
-
+#[wll::init]
+fn init() {
     // Register `manage_instance()` as the handler for managed expressions created using:
     //
     //     CreateManagedLibraryExpression["my_object", _]
     wll::managed::register_library_expression_manager("my_object", manage_instance);
-
-    return 0;
 }
 
 fn manage_instance(action: ManagedExpressionEvent) {

--- a/wolfram-library-link/examples/tests/test_native_args.rs
+++ b/wolfram-library-link/examples/tests/test_native_args.rs
@@ -23,6 +23,7 @@ wll::export![
     // test_str(_);
     test_string(_);
     test_c_string(_);
+    test_panic();
 ];
 
 fn test_no_args() -> i64 {
@@ -92,6 +93,14 @@ fn test_string(string: String) -> String {
 
 fn test_c_string(string: CString) -> i64 {
     i64::try_from(string.as_bytes().len()).expect("string len usize overflows i64")
+}
+
+//-------
+// Panics
+//-------
+
+fn test_panic() {
+    panic!("this function panicked");
 }
 
 //======================================

--- a/wolfram-library-link/src/lib.rs
+++ b/wolfram-library-link/src/lib.rs
@@ -120,6 +120,7 @@ pub use self::{
 };
 
 
+
 use std::sync::Mutex;
 
 use once_cell::sync::Lazy;
@@ -130,6 +131,53 @@ use wstp::Link;
 pub(crate) use self::library_data::assert_main_thread;
 use crate::expr::{Expr, ExprKind, Symbol};
 
+//--------------------------------------
+// Re-exported items
+//--------------------------------------
+
+/// Designate an initialization function to run when this library is loaded via Wolfram
+/// LibraryLink.
+///
+/// `#[init]` can be applied to at most one function in a library.
+///
+/// The function annotated with `#[init]` will automatically call [`initialize()`].
+///
+/// LibraryLink libraries are not required to define an initialization function.
+///
+/// # Panics
+///
+/// Any panics thrown during the executation of `#[init]` will automatically be caught,
+/// and an error code will be returned to the Wolfram Kernel.
+///
+// TODO: Mention which error code specifically:
+//         `macro_utils::error_code::FAILED_WITH_PANIC`.
+///
+/// If the initialization function panics, the Kernel will prevent other LibraryLink
+/// functions exported from that library from being loaded.
+///
+/// # Example
+///
+/// Define an initialization function:
+///
+/// ```rust
+/// use wolfram_library_link as wll;
+///
+/// #[wll::init]
+/// fn init_my_library() {
+///     println!("library is now initialized");
+/// }
+/// ```
+///
+/// # Behavior
+///
+/// If a library exports a function [called `WolframLibrary_initialize()`][lib-init], that
+/// function will automatically be called by the Wolfram Kernel when the library is
+/// loaded.
+///
+/// `#[init]` works by generating a definition for `WolframLibrary_initialize()`.
+///
+/// [lib-init]: https://reference.wolfram.com/language/LibraryLink/tutorial/LibraryStructure.html#280210622
+pub use wll_proc_macros::init;
 
 const BACKTRACE_ENV_VAR: &str = "LIBRARY_LINK_RUST_BACKTRACE";
 

--- a/wolfram-library-link/src/library_data.rs
+++ b/wolfram-library-link/src/library_data.rs
@@ -27,7 +27,8 @@ static LIBRARY_DATA: OnceCell<Data> = OnceCell::new();
 
 /// Initialize static data for the current Wolfram library.
 ///
-/// This function should be called during the execution of the [`WolframLibrary_initialize()` hook][lib-init]
+/// This function should be called during the execution of the
+/// [`WolframLibrary_initialize()` hook][lib-init]
 /// provided by this library.
 ///
 /// This function initializes the lazy Wolfram Runtime Library bindings in the
@@ -42,7 +43,16 @@ static LIBRARY_DATA: OnceCell<Data> = OnceCell::new();
 /// * The call to `initialize()` must happen from the main Kernel thread. This is true for
 ///   all LibraryLink functions called directly by the Kernel.
 ///
+/// # Relation to [`#[init]`][crate::init]
+///
+/// If the [`#[init]`][crate::init] annotation is used to designate a library
+/// initialization function, `initialize()` will be called automatically.
+///
 /// # Example
+///
+/// *Note: Prefer to use [`#[init]`][crate::init] to designate an initialization function,
+/// instead of manually defining an unsafe initialization function as shown in this
+/// example.*
 ///
 /// When a dynamic library is loaded by the Wolfram Language (for example, via
 /// [`LibraryFunctionLoad`](https://reference.wolfram.com/language/ref/LibraryFunctionLoad.html)),

--- a/wolfram-library-link/src/macro_utils.rs
+++ b/wolfram-library-link/src/macro_utils.rs
@@ -112,7 +112,7 @@ pub unsafe fn call_native_wolfram_library_function<'a, F: NativeFunction<'a>>(
     res: MArgument,
     func: F,
 ) -> c_uint {
-    use std::panic::{self, AssertUnwindSafe};
+    use std::panic::AssertUnwindSafe;
 
     // Initialize the library.
     if crate::initialize(lib_data).is_err() {
@@ -129,7 +129,7 @@ pub unsafe fn call_native_wolfram_library_function<'a, F: NativeFunction<'a>>(
     //        E.g. `fn foo(link: &'static mut str) { ... }`
     let args: &[MArgument] = std::slice::from_raw_parts(args, argc);
 
-    if panic::catch_unwind(AssertUnwindSafe(move || func.call(args, res))).is_err() {
+    if call_and_catch_panic(AssertUnwindSafe(move || func.call(args, res))).is_err() {
         // TODO: Store the panic into a "LAST_ERROR" static, and provide an accessor to
         //       get it from WL? E.g. RustLink`GetLastError[<optional func name>].
         return error_code::FAILED_WITH_PANIC;

--- a/wolfram-library-link/src/macro_utils.rs
+++ b/wolfram-library-link/src/macro_utils.rs
@@ -1,4 +1,4 @@
-use std::os::raw::c_uint;
+use std::os::raw::{c_int, c_uint};
 
 use wstp::{self, Link};
 
@@ -335,5 +335,24 @@ impl LibraryLinkFunction {
         };
 
         Ok(code)
+    }
+}
+
+//======================================
+// Initialization
+//======================================
+
+pub unsafe fn init_with_user_function(
+    lib: sys::WolframLibraryData,
+    user_init_func: fn(),
+) -> c_int {
+    if let Err(()) = crate::initialize(lib) {
+        return error_code::FAILED_TO_INIT as c_int;
+    }
+
+    if let Err(_) = call_and_catch_panic(user_init_func) {
+        error_code::FAILED_WITH_PANIC as c_int
+    } else {
+        sys::LIBRARY_NO_ERROR as c_int
     }
 }

--- a/wolfram-library-link/src/managed.rs
+++ b/wolfram-library-link/src/managed.rs
@@ -244,10 +244,7 @@ fn call_callback_in_slot(slot: usize, mode: sys::mbool, id: sys::mint) {
         _ => panic!("unknown managed expression 'mode' value: {}", mode),
     };
 
-    if let Err(_) = crate::catch_panic::call_and_catch_panic(|| user_fn(action)) {
-        // Do nothing.
-        // TODO: Set something like "RustLink`$LibraryLastError" with this panic?
-    }
+    user_fn(action)
 }
 
 macro_rules! def_slot_fn {
@@ -258,7 +255,14 @@ macro_rules! def_slot_fn {
             mode: sys::mbool,
             id: sys::mint,
         ) {
-            call_callback_in_slot($index, mode, id)
+            let result = crate::catch_panic::call_and_catch_panic(|| {
+                call_callback_in_slot($index, mode, id)
+            });
+
+            if let Err(_) = result {
+                // Do nothing.
+                // TODO: Set something like "RustLink`$LibraryLastError" with this panic?
+            }
         }
     };
 }

--- a/wolfram-library-link/src/managed.rs
+++ b/wolfram-library-link/src/managed.rs
@@ -95,13 +95,17 @@ pub fn register_library_expression_manager(
 ///
 /// `registerLibraryExpressionManager()` expects a callback function of the type:
 ///
-///     unsafe extern "C"(WolframLibraryData, mbool, mint)
+/// ```ignore
+///     unsafe extern "C" fn(WolframLibraryData, mbool, mint)
+/// ```
 ///
 /// however, for the purpose of providing a more ergonomic and safe wrapper to the user,
 /// we want the user to be able to pass `register_library_expression_manager()` a callback
 /// function with the type:
 ///
+/// ```ignore
 ///     fn(ManagedExpressionAction)
+/// ```
 ///
 /// This specific problem is an instance of the more general problem of how to expose a
 /// user-provided function/closure (non-`extern "C"`) as-if it actually were an

--- a/wolfram-library-link/wll-proc-macros/Cargo.toml
+++ b/wolfram-library-link/wll-proc-macros/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "wll-proc-macros"
+version = "0.1.0"
+license = "MIT OR Apache-2.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1.0.36"
+syn = { version = "1.0.85", features = [] }
+quote = "1.0.14"

--- a/wolfram-library-link/wll-proc-macros/src/lib.rs
+++ b/wolfram-library-link/wll-proc-macros/src/lib.rs
@@ -1,0 +1,93 @@
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+
+use quote::quote;
+use syn::{spanned::Spanned, Error, Item};
+
+//======================================
+// #[wolfram_library_link::init]
+//======================================
+
+#[proc_macro_attribute]
+pub fn init(
+    attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    match init_(attr.into(), item) {
+        Ok(tokens) => tokens.into(),
+        Err(err) => err.into_compile_error().into(),
+    }
+}
+
+fn init_(attr: TokenStream2, item: TokenStream) -> Result<TokenStream2, Error> {
+    // Validate that we got `#[init]` and not `#[init(some, unexpected, arguments)]`.
+    if !attr.is_empty() {
+        return Err(Error::new(attr.span(), "unexpected attribute arguments"));
+    }
+
+    //--------------------------------------------------------------------
+    // Validate that this attribute was applied to a `fn(..) { .. }` item.
+    //--------------------------------------------------------------------
+
+    let item: Item = syn::parse(item)?;
+
+    let func = match item {
+        Item::Fn(func) => func,
+        _ => {
+            return Err(Error::new(
+                attr.span(),
+                "this attribute can only be applied to `fn(..) {..}` items",
+            ))
+        },
+    };
+
+    //-------------------------
+    // Validate the user `func`
+    //-------------------------
+
+    // No `async`
+    if let Some(async_) = func.sig.asyncness {
+        return Err(Error::new(
+            async_.span(),
+            "initialization function cannot be `async`",
+        ));
+    }
+
+    // No generics
+    if let Some(lt) = func.sig.generics.lt_token {
+        return Err(Error::new(
+            lt.span(),
+            "initialization function cannot be generic",
+        ));
+    }
+
+    // No parameters
+    if !func.sig.inputs.is_empty() {
+        return Err(Error::new(
+            func.sig.inputs.span(),
+            "initialization function should have zero parameters",
+        ));
+    }
+
+    //--------------------------------------------------------
+    // Create the output WolframLibrary_initialize() function.
+    //--------------------------------------------------------
+
+    let user_init_fn_name: syn::Ident = func.sig.ident.clone();
+
+    let output = quote! {
+        #func
+
+        #[no_mangle]
+        pub unsafe extern "C" fn WolframLibrary_initialize(
+            lib: ::wolfram_library_link::sys::WolframLibraryData,
+        ) -> ::std::os::raw::c_int {
+            ::wolfram_library_link::macro_utils::init_with_user_function(
+                lib,
+                #user_init_fn_name
+            )
+        }
+    };
+
+    Ok(output)
+}


### PR DESCRIPTION
The new `#[init]` macro is an alternative to manually defining a `WolframLIbrary_initialize()` function.

**Before:**

```rust
#[no_mangle]
pub unsafe extern "C" fn WolframLibrary_initialize(data: sys::WolframLibraryData) -> c_int {
    match wll::initialize() {
        Ok(()) => 0,
        Err(()) => 1,
    }

    // Initialization tasks. Careful not to `panic!()`!
}
```

**After:**

```rust
#[wll::init]
fn init() {
    // Initialization tasks. Okay to !panic!()`.
}
```