### PR TITLE
fixup: Preserve commit that the v0.1.0 release of wolfram-library-link-sys was made from

### DIFF
--- a/wolfram-library-link-sys/Cargo.toml
+++ b/wolfram-library-link-sys/Cargo.toml
@@ -4,6 +4,11 @@ version = "0.1.0"
 authors = ["Connor Gray <code@connorgray.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2018"
+readme = "README.md"
+repository = "https://github.com/WolframResearch/wolfram-library-link-rs"
+description = "Low-level FFI bindings to the Wolfram LibraryLink C API"
+keywords = ["wolfram-library-link", "wstp", "wolfram", "wolfram-language", "wolfram-engine"]
+categories = ["external-ffi-bindings", "development-tools::ffi"]
 
 # TODO: Use the 'links' key?
 #       See: https://doc.rust-lang.org/cargo/reference/build-scripts.html#a-sys-packages
@@ -11,4 +16,4 @@ edition = "2018"
 [dependencies]
 
 [build-dependencies]
-wolfram-app-discovery = { git = "https://github.com/WolframResearch/wolfram-app-discovery-rs" }
+wolfram-app-discovery = "0.1.1"

--- a/wolfram-library-link-sys/README.md
+++ b/wolfram-library-link-sys/README.md
@@ -1,0 +1,7 @@
+# wolfram-library-link-sys
+
+Low-level FFI bindings to the
+[Wolfram LibraryLink C API](https://reference.wolfram.com/language/LibraryLink/tutorial/LibraryStructure.html).
+
+The [`wolfram-library-link`](https://crates.io/crates/wolfram-library-link) crate provides
+efficient and idiomatic Rust bindings to Wolfram LibraryLink based on these raw bindings.


### PR DESCRIPTION
See the CHANGELOG.md entry discussing v0.1.0 for details.

Add wolfram-library-link-sys Cargo.toml  fields: readme, repository, description, keywords, categories + stub README.md