### PR TITLE
chore: Update wolfram-app-discovery and wstp dependency versions

### DIFF
--- a/wolfram-library-link-sys/Cargo.toml
+++ b/wolfram-library-link-sys/Cargo.toml
@@ -16,4 +16,4 @@ categories = ["external-ffi-bindings", "development-tools::ffi"]
 [dependencies]
 
 [build-dependencies]
-wolfram-app-discovery = "0.1.2"
+wolfram-app-discovery = "0.2.1"

--- a/wolfram-library-link/Cargo.toml
+++ b/wolfram-library-link/Cargo.toml
@@ -15,7 +15,7 @@ wolfram-library-link-macros    = { version = "0.1.2", path = "./wolfram-library-
 
 wolfram-library-link-sys       = { version = "0.1.2", path = "../wolfram-library-link-sys" }
 
-wstp         = "0.1.3"
+wstp         = "0.2.1"
 wolfram-expr = "0.1.0"
 
 once_cell = "1.8.0"


### PR DESCRIPTION
The newer versions of these two dependencies have better support for
Windows, and are less limited wrt. Wolfram Language versions they can
be built against.