### PR TITLE
bugfix: Fix docs.rs build failure due to case-sensitive file name mismatch

### DIFF
--- a/wolfram-library-link/src/docs/converting_between_rust_and_wolfram_types.rs
+++ b/wolfram-library-link/src/docs/converting_between_rust_and_wolfram_types.rs
@@ -45,7 +45,7 @@ transfering the expression using [WSTP](https://crates.io/crates/wstp), via the
 
 ```wolfram
 */
-#![doc = include_str!("../../RustLink/Examples/Docs/Convert/ManualWstp.wlt")]
+#![doc = include_str!("../../RustLink/Examples/Docs/Convert/ManualWSTP.wlt")]
 /*!
 ```
 


### PR DESCRIPTION
The file is called ManualWSTP.wlt, but the include_str!(..) call used "ManualWstp.wlt".

This worked on macOS (where I develop) because macOS is case-insensitive. This failed
on docs.rs because docs.rs uses Linux build environments, and Linux is case-sensitive.