### PR TITLE
chore: Update wolfram-app-discovery dependency from 0.2.1 to 0.3.0

### DIFF
--- a/wolfram-library-link-sys/Cargo.toml
+++ b/wolfram-library-link-sys/Cargo.toml
@@ -18,4 +18,4 @@ categories = ["external-ffi-bindings", "development-tools::ffi"]
 [build-dependencies]
 bindgen = "0.59.2"
 
-wolfram-app-discovery = "0.2.1"
+wolfram-app-discovery = "0.3.0"


### PR DESCRIPTION
This makes the build script logic more flexible and configurable by environment variable.