### PR TITLE
chore: Update wstp and wolfram-app-discovery dependencies

### DIFF
--- a/wolfram-library-link-sys/Cargo.toml
+++ b/wolfram-library-link-sys/Cargo.toml
@@ -18,4 +18,4 @@ categories = ["external-ffi-bindings", "development-tools::ffi"]
 [build-dependencies]
 bindgen = "0.59.2"
 
-wolfram-app-discovery = "0.3.0"
+wolfram-app-discovery = "0.4.1"

--- a/wolfram-library-link/Cargo.toml
+++ b/wolfram-library-link/Cargo.toml
@@ -24,7 +24,7 @@ wolfram-library-link-macros    = { version = "0.2.7", path = "./wolfram-library-
 
 wolfram-library-link-sys       = { version = "0.2.7", path = "../wolfram-library-link-sys" }
 
-wstp         = "0.2.1"
+wstp         = "0.2.6"
 wolfram-expr = "0.1.0"
 
 once_cell = "1.8.0"


### PR DESCRIPTION
This ensures that the latest wolfram-app-discovery v0.4.1 is being used everywhere, which has better Linux support and fixes a couple of bugs.