### PR TITLE
cleanup: Reduce dependencies by making them optional and adding new cargo features

### DIFF
--- a/docs/Maintenance.md
+++ b/docs/Maintenance.md
@@ -5,6 +5,19 @@ This document describes tasks necessary to maintain the `wolfram-library-link` a
 for the maintainer of these crates; users of these crates do not need to read this
 document.
 
+## Release
+
+### Check that common feature combinations compile successfully
+
+```shell
+$ cargo check --all-features --all-targets --tests --examples --benches
+```
+
+```shell
+$ cargo check --no-default-features --all-targets --tests --examples --benches
+```
+
+
 ## Generating `wolfram-library-link-sys` bindings
 
 After every Wolfram Language release, the pre-generated bindings stored in the

--- a/wolfram-library-link/Cargo.toml
+++ b/wolfram-library-link/Cargo.toml
@@ -28,17 +28,22 @@ wstp         = "0.2.6"
 wolfram-expr = "0.1.0"
 
 once_cell = "1.8.0"
-backtrace = "^0.3.46"
 static_assertions = "1.1.0"
 ref-cast = "1.0.6"
-inventory = "0.2.1"
-process_path = "0.1.3"
+
+backtrace = { version = "^0.3.46", optional = true }
+inventory = { version = "0.2.1", optional = true }
+process_path = { version = "0.1.3", optional = true }
 
 [dev-dependencies]
 
 [features]
-default = []
+default = ["panic-failure-backtraces", "automate-function-loading-boilerplate"]
 nightly = []
+
+panic-failure-backtraces = ["backtrace"]
+automate-function-loading-boilerplate = ["inventory", "process_path", "wolfram-library-link-macros/automate-function-loading-boilerplate"]
+
 
 #=======================================
 # Examples
@@ -47,6 +52,7 @@ nightly = []
 [[example]]
 name = "basic_types"
 crate-type = ["cdylib"]
+required-features = ["automate-function-loading-boilerplate"]
 
 [[example]]
 name = "numeric_arrays"
@@ -64,6 +70,7 @@ crate-type = ["cdylib"]
 name = "wstp_example" # avoid "libwstp.dylib", which seems too generic.
 path = "examples/wstp.rs"
 crate-type = ["cdylib"]
+required-features = ["automate-function-loading-boilerplate"]
 
 #-----------------------------
 # Raw (unsafe, low-level) APIs
@@ -92,6 +99,7 @@ crate-type = ["cdylib"]
 name = "managed_exprs"
 path = "examples/exprs/managed.rs"
 crate-type = ["cdylib"]
+required-features = ["automate-function-loading-boilerplate"]
 
 #---------------
 # Async examples

--- a/wolfram-library-link/src/lib.rs
+++ b/wolfram-library-link/src/lib.rs
@@ -249,9 +249,15 @@ pub use wolfram_expr as expr;
 pub use wolfram_library_link_sys as sys;
 pub use wstp;
 
+
 // Used by the #[export]/#[export(wstp)] macro implementations.
+#[cfg(feature = "automate-function-loading-boilerplate")]
 #[doc(hidden)]
 pub use inventory;
+
+#[cfg(feature = "automate-function-loading-boilerplate")]
+pub use self::macro_utils::exported_library_functions_association;
+
 
 pub use self::{
     args::{FromArg, IntoArg, NativeFunction, WstpFunction},
@@ -259,7 +265,6 @@ pub use self::{
     data_store::{DataStore, DataStoreNode, DataStoreNodeValue, Nodes},
     image::{ColorSpace, Image, ImageData, ImageType, Pixel, UninitImage},
     library_data::{get_library_data, initialize, WolframLibraryData},
-    macro_utils::exported_library_functions_association,
     numeric_array::{
         NumericArray, NumericArrayConvertMethod, NumericArrayDataType, NumericArrayKind,
         NumericArrayType, UninitNumericArray,
@@ -902,6 +907,7 @@ fn bool_from_mbool(boole: sys::mbool) -> bool {
 /// ```
 ///
 /// [ref/LibraryFunctionLoad]: https://reference.wolfram.com/language/ref/LibraryFunctionLoad.html
+#[cfg(feature = "automate-function-loading-boilerplate")]
 #[macro_export]
 macro_rules! generate_loader {
     ($name:ident) => {

--- a/wolfram-library-link/src/macro_utils.rs
+++ b/wolfram-library-link/src/macro_utils.rs
@@ -1,4 +1,4 @@
-use std::{os::raw::c_int, path::PathBuf};
+use std::os::raw::c_int;
 
 use wstp::{self, Link};
 
@@ -217,8 +217,10 @@ pub enum LibraryLinkFunction {
     },
 }
 
+#[cfg(feature = "automate-function-loading-boilerplate")]
 inventory::collect!(LibraryLinkFunction);
 
+#[cfg(feature = "automate-function-loading-boilerplate")]
 pub unsafe fn load_library_functions_impl(
     lib_data: sys::WolframLibraryData,
     raw_link: wstp::sys::WSLINK,
@@ -437,8 +439,11 @@ pub unsafe fn load_library_functions_impl(
 ///
 /// [Association]: https://reference.wolfram.com/language/ref/Association.html
 /// [LibraryFunctionLoad]: https://reference.wolfram.com/language/ref/LibraryFunctionLoad.html
-pub fn exported_library_functions_association(library: Option<PathBuf>) -> Expr {
-    let library: PathBuf = library.unwrap_or_else(|| {
+#[cfg(feature = "automate-function-loading-boilerplate")]
+pub fn exported_library_functions_association(
+    library: Option<std::path::PathBuf>,
+) -> Expr {
+    let library: std::path::PathBuf = library.unwrap_or_else(|| {
         process_path::get_dylib_path()
             .expect("unable to automatically determine Rust LibraryLink dynamic library file path. Suggestion: pass the library name or path to exported_library_functions_association(..)")
     });
@@ -461,6 +466,10 @@ pub fn exported_library_functions_association(library: Option<PathBuf>) -> Expr 
     Expr::normal(Symbol::new("System`Association"), fields)
 }
 
+#[cfg_attr(
+    not(feature = "automate-function-loading-boilerplate"),
+    allow(dead_code)
+)]
 impl LibraryLinkFunction {
     fn name(&self) -> &str {
         match self {

--- a/wolfram-library-link/src/numeric_array.rs
+++ b/wolfram-library-link/src/numeric_array.rs
@@ -1,9 +1,9 @@
 use std::ffi::c_void;
 use std::fmt;
 use std::marker::PhantomData;
-use std::mem::MaybeUninit;
+use std::mem::{self, MaybeUninit};
 
-use static_assertions::{assert_eq_align, assert_eq_size, assert_not_impl_any};
+use static_assertions::assert_not_impl_any;
 
 use crate::{rtl, sys};
 
@@ -220,8 +220,8 @@ pub enum NumericArrayKind<'e> {
 
 // Assert that `sys::mcomplex` is the 64-bit complex real type and not a 32-bit complex
 // real type.
-assert_eq_size!(sys::mcomplex, [f64; 2]);
-assert_eq_align!(sys::mcomplex, f64);
+const _: () = assert!(mem::size_of::<sys::mcomplex>() == mem::size_of::<[f64; 2]>());
+const _: () = assert!(mem::align_of::<sys::mcomplex>() == mem::align_of::<f64>());
 
 //======================================
 // Impls
@@ -605,7 +605,7 @@ impl<T> NumericArray<T> {
         let dims: *const crate::sys::mint =
             unsafe { rtl::MNumericArray_getDimensions(numeric_array) };
 
-        assert_eq_size!(sys::mint, usize);
+        const _: () = assert!(mem::size_of::<sys::mint>() == mem::size_of::<usize>());
         let dims: *mut usize = dims as *mut usize;
 
         debug_assert!(!dims.is_null());

--- a/wolfram-library-link/wolfram-library-link-macros/Cargo.toml
+++ b/wolfram-library-link/wolfram-library-link-macros/Cargo.toml
@@ -15,3 +15,8 @@ proc-macro = true
 proc-macro2 = "1.0.36"
 syn = { version = "1.0.85", features = ["full"] }
 quote = "1.0.14"
+
+[features]
+default = []
+
+automate-function-loading-boilerplate = []

--- a/wolfram-library-link/wolfram-library-link-macros/src/export.rs
+++ b/wolfram-library-link/wolfram-library-link-macros/src/export.rs
@@ -193,7 +193,7 @@ fn export_native_function(
 
     };
 
-    if !hidden {
+    if !hidden && cfg!(feature = "automate-function-loading-boilerplate") {
         tokens.extend(quote! {
             // Register this exported function.
             ::wolfram_library_link::inventory::submit! {
@@ -257,7 +257,7 @@ fn export_wstp_function(
         }
     };
 
-    if !hidden {
+    if !hidden && cfg!(feature = "automate-function-loading-boilerplate") {
         tokens.extend(quote! {
             // Register this exported function.
             ::wolfram_library_link::inventory::submit! {


### PR DESCRIPTION
This PR adds two new cargo features to wolfram-library-link:
    
* `panic-failure-backtraces`
* `automate-library-function-boilterplate`
    
which are enabled by default.
    
These features are used to control whether the following (now optional) dependencies are enabled:
    
* backtrace
* inventory
* process_path
    
Making these dependencies optional significantly reduces the overall size of the `cargo tree` dependency graph of this crate.