### PR TITLE
chore: Update wstp dependency to v0.2.8

### DIFF
--- a/wolfram-library-link/Cargo.toml
+++ b/wolfram-library-link/Cargo.toml
@@ -24,7 +24,7 @@ wolfram-library-link-macros    = { version = "0.2.9", path = "./wolfram-library-
 
 wolfram-library-link-sys       = { version = "0.2.9", path = "../wolfram-library-link-sys" }
 
-wstp         = "0.2.6"
+wstp         = "0.2.8"
 wolfram-expr = "0.1.0"
 
 once_cell = "1.8.0"


### PR DESCRIPTION
This updates wstp to a version that no longer depends on bindgen at build time. This indirectly works around [bindgen #2312](https://github.com/rust-lang/rust-bindgen/issues/2312), while also simplifying the wolfram-library-link dependency tree and reducing build times. 