### PR TITLE
feature: Add experimental support for constructing Kernel exprs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,8 @@
 [alias]
 xtask = "run --package xtask --"
+
+# Avoid undefined symbol errors produced by the linker when calling functions
+# declared in wolfram-library-link/src/kernel/sys.rs that aren't resolved until
+# the built LibraryLink library is loaded into a running Kernel.
+[build]
+rustflags = ["-C", "link-args=-undefined dynamic_lookup"]

--- a/wolfram-library-link/Cargo.toml
+++ b/wolfram-library-link/Cargo.toml
@@ -44,6 +44,8 @@ nightly = []
 panic-failure-backtraces = ["backtrace"]
 automate-function-loading-boilerplate = ["inventory", "process_path", "wolfram-library-link-macros/automate-function-loading-boilerplate"]
 
+experimental-kernel-expr = []
+
 
 #=======================================
 # Examples

--- a/wolfram-library-link/RustLink/Tests/KernelExpr.wlt
+++ b/wolfram-library-link/RustLink/Tests/KernelExpr.wlt
@@ -29,3 +29,13 @@ Test[
 	),
 	{1, 2.01, "three", Four, {"a", "b", "c"}}
 ]
+
+Test[
+	(
+		LibraryFunctionLoad[
+			"liblibrary_tests", "test_kernel_expr_evaluate", {}, "Void"
+		][];
+		Global`$ReturnValue
+	),
+	4
+]

--- a/wolfram-library-link/RustLink/Tests/KernelExpr.wlt
+++ b/wolfram-library-link/RustLink/Tests/KernelExpr.wlt
@@ -1,0 +1,21 @@
+Needs["MUnit`"]
+
+Test[
+	(
+		LibraryFunctionLoad[
+			"liblibrary_tests", "test_kernel_expr_create_string", {}, "Void"
+		][];
+		Global`$ReturnValue
+	),
+	{1, "two"}
+]
+
+Test[
+	(
+		LibraryFunctionLoad[
+			"liblibrary_tests", "test_kernel_expr_create_symbols", {}, "Void"
+		][];
+		Global`$ReturnValue
+	),
+	{Global`Example1, Global`Example2, Example3`Example4}
+]

--- a/wolfram-library-link/RustLink/Tests/KernelExpr.wlt
+++ b/wolfram-library-link/RustLink/Tests/KernelExpr.wlt
@@ -7,7 +7,7 @@ Test[
 		][];
 		Global`$ReturnValue
 	),
-	{1, "two"}
+	{1, "two", 3.5}
 ]
 
 Test[

--- a/wolfram-library-link/RustLink/Tests/KernelExpr.wlt
+++ b/wolfram-library-link/RustLink/Tests/KernelExpr.wlt
@@ -39,3 +39,18 @@ Test[
 	),
 	4
 ]
+
+(*====================================*)
+(* Custom DownCode                    *)
+(*====================================*)
+
+Test[
+	(
+		LibraryFunctionLoad[
+			"liblibrary_tests", "test_kernel_expr_custom_downcode", {}, "Void"
+		][];
+
+		Global`CustomDownCode[]
+	),
+	"CUSTOM DOWNCODE"
+]

--- a/wolfram-library-link/RustLink/Tests/KernelExpr.wlt
+++ b/wolfram-library-link/RustLink/Tests/KernelExpr.wlt
@@ -19,3 +19,13 @@ Test[
 	),
 	{Global`Example1, Global`Example2, Example3`Example4}
 ]
+
+Test[
+	(
+		LibraryFunctionLoad[
+			"liblibrary_tests", "test_kernel_expr_create_heterogenous", {}, "Void"
+		][];
+		Global`$ReturnValue
+	),
+	{1, 2.01, "three", Four, {"a", "b", "c"}}
+]

--- a/wolfram-library-link/examples/tests/main.rs
+++ b/wolfram-library-link/examples/tests/main.rs
@@ -6,3 +6,5 @@ mod test_data_store;
 mod test_images;
 mod test_numeric_array_conversions;
 mod test_wstp;
+
+mod test_kernel_expr;

--- a/wolfram-library-link/examples/tests/test_kernel_expr.rs
+++ b/wolfram-library-link/examples/tests/test_kernel_expr.rs
@@ -1,0 +1,24 @@
+use wolfram_library_link::{
+    export,
+    kernel::{Expr, NormalExpr, SymbolExpr},
+};
+
+#[export]
+fn test_kernel_expr_create_string() {
+    let list = NormalExpr::list_from_array([Expr::mint(1), Expr::string("two")]);
+
+    // $ReturnValue = list
+    SymbolExpr::lookup("Global`$ReturnValue").set_to(&list.as_expr());
+}
+
+#[export]
+fn test_kernel_expr_create_symbols() {
+    let list = NormalExpr::list_from_array([
+        SymbolExpr::lookup("Example1").into(),
+        SymbolExpr::lookup("`Example2").into(),
+        SymbolExpr::lookup("Example3`Example4").into(),
+    ]);
+
+    // $ReturnValue = list
+    SymbolExpr::lookup("Global`$ReturnValue").set_to(&list.as_expr());
+}

--- a/wolfram-library-link/examples/tests/test_kernel_expr.rs
+++ b/wolfram-library-link/examples/tests/test_kernel_expr.rs
@@ -1,6 +1,6 @@
 use wolfram_library_link::{
     export,
-    kernel::{self, Expr, MIntExpr, NormalExpr, SymbolExpr},
+    kernel::{self, Expr, MIntExpr, NormalExpr, SymbolExpr, UncountedExpr},
 };
 
 #[export]
@@ -57,4 +57,21 @@ fn test_kernel_expr_evaluate() {
 
     // $ReturnValue = list
     SymbolExpr::lookup("Global`$ReturnValue").set_to(&result.as_expr());
+}
+
+//======================================
+// Custom DownCode
+//======================================
+
+extern "C" fn eval_downcode(expr: UncountedExpr) -> Expr {
+    let _normal = NormalExpr::try_from_expr_ref(expr.as_expr()).unwrap();
+
+    Expr::string("CUSTOM DOWNCODE")
+}
+
+#[export]
+fn test_kernel_expr_custom_downcode() {
+    let symbol = SymbolExpr::lookup("Global`CustomDownCode");
+
+    symbol.set_downcode(Some(eval_downcode))
 }

--- a/wolfram-library-link/examples/tests/test_kernel_expr.rs
+++ b/wolfram-library-link/examples/tests/test_kernel_expr.rs
@@ -1,6 +1,6 @@
 use wolfram_library_link::{
     export,
-    kernel::{Expr, NormalExpr, SymbolExpr},
+    kernel::{self, Expr, MIntExpr, NormalExpr, SymbolExpr},
 };
 
 #[export]
@@ -36,6 +36,24 @@ fn test_kernel_expr_create_heterogenous() {
         Expr::symbol("Global`Four"),
         Expr::list_from_array([Expr::string("a"), Expr::string("b"), Expr::string("c")]),
     ]);
+
+    // $ReturnValue = list
+    SymbolExpr::lookup("Global`$ReturnValue").set_to(&result.as_expr());
+}
+
+#[export]
+fn test_kernel_expr_evaluate() {
+    // Evaluate Plus[2, 2]
+    let result = kernel::eval(
+        &NormalExpr::from_slice(&Expr::symbol("System`Plus"), &[
+            Expr::mint(2),
+            Expr::mint(2),
+        ])
+        .into(),
+    );
+
+    let result = MIntExpr::try_from_expr(result)
+        .expect("expected result of evaluating 2 + 2 to be MIntExpr");
 
     // $ReturnValue = list
     SymbolExpr::lookup("Global`$ReturnValue").set_to(&result.as_expr());

--- a/wolfram-library-link/examples/tests/test_kernel_expr.rs
+++ b/wolfram-library-link/examples/tests/test_kernel_expr.rs
@@ -5,7 +5,11 @@ use wolfram_library_link::{
 
 #[export]
 fn test_kernel_expr_create_string() {
-    let list = NormalExpr::list_from_array([Expr::mint(1), Expr::string("two")]);
+    let list = NormalExpr::list_from_array([
+        Expr::mint(1),
+        Expr::string("two"),
+        Expr::mreal(3.5),
+    ]);
 
     // $ReturnValue = list
     SymbolExpr::lookup("Global`$ReturnValue").set_to(&list.as_expr());

--- a/wolfram-library-link/examples/tests/test_kernel_expr.rs
+++ b/wolfram-library-link/examples/tests/test_kernel_expr.rs
@@ -26,3 +26,17 @@ fn test_kernel_expr_create_symbols() {
     // $ReturnValue = list
     SymbolExpr::lookup("Global`$ReturnValue").set_to(&list.as_expr());
 }
+
+#[export]
+fn test_kernel_expr_create_heterogenous() {
+    let result = NormalExpr::list_from_array([
+        Expr::mint(1),
+        Expr::mreal(2.01),
+        Expr::string("three"),
+        Expr::symbol("Global`Four"),
+        Expr::list_from_array([Expr::string("a"), Expr::string("b"), Expr::string("c")]),
+    ]);
+
+    // $ReturnValue = list
+    SymbolExpr::lookup("Global`$ReturnValue").set_to(&result.as_expr());
+}

--- a/wolfram-library-link/src/kernel.rs
+++ b/wolfram-library-link/src/kernel.rs
@@ -32,18 +32,84 @@ pub struct Uninit<T>(ManuallyDrop<T>);
 
 impl Expr {
     /// Construct a machine-sized Integer expression.
+    ///
+    /// # Examples
+    ///
+    /// Construct the expression `42`:
+    ///
+    /// ```no_run
+    /// use wolfram_library_link::kernel::Expr;
+    ///
+    /// let e = Expr::mint(42);
+    /// ```
     pub fn mint(value: mint) -> Expr {
         MIntExpr::new(value).into_expr()
     }
 
     /// Construct a machine-sized Real expression.
+    ///
+    /// # Examples
+    ///
+    /// Construct the expression `1.23`:
+    ///
+    /// ```no_run
+    /// use wolfram_library_link::kernel::Expr;
+    ///
+    /// let e = Expr::mreal(1.23);
+    /// ```
     pub fn mreal(value: mreal) -> Expr {
         MRealExpr::new(value).into_expr()
     }
 
     /// Construct a String expression.
+    ///
+    /// # Examples
+    ///
+    /// Construct the expression `"Hello, Wolfram!"`:
+    ///
+    /// ```no_run
+    /// use wolfram_library_link::kernel::Expr;
+    ///
+    /// let e = Expr::string("Hello, Wolfram!");
+    /// ```
     pub fn string(string: &str) -> Expr {
         StringExpr::new(string).into_expr()
+    }
+
+    /// Construct a Symbol expression.
+    ///
+    /// # Examples
+    ///
+    /// Construct the expression `` System`Now ``:
+    ///
+    /// ```no_run
+    /// use wolfram_library_link::kernel::Expr;
+    ///
+    /// let e = Expr::symbol("System`Now");
+    /// ```
+    pub fn symbol(symbol: &str) -> Expr {
+        // FIXME: Validate that `symbol` is a valid symbol name or fully
+        //        qualified symbol.
+        SymbolExpr::lookup(symbol).into_expr()
+    }
+
+    /// Construct a new `{...}` expression from an array of expressions.
+    ///
+    /// # Examples
+    ///
+    /// Construct the expression `{1, 2, 3}`:
+    ///
+    /// ```no_run
+    /// use wolfram_library_link::kernel::Expr;
+    ///
+    /// let list = Expr::list_from_array([
+    ///     Expr::mint(1),
+    ///     Expr::mint(2),
+    ///     Expr::mint(3)
+    /// ]);
+    /// ```
+    pub fn list_from_array<const N: usize>(array: [Expr; N]) -> Expr {
+        NormalExpr::list_from_array(array).into_expr()
     }
 
     /// Get the expression flags.

--- a/wolfram-library-link/src/kernel/expr_types.rs
+++ b/wolfram-library-link/src/kernel/expr_types.rs
@@ -1,0 +1,238 @@
+use crate::kernel::{predicates, sys};
+
+/// Wolfram Kernel expr.
+///
+/// Wolfram Kernel expressions are immutable.
+#[derive(Debug)]
+#[repr(transparent)]
+pub struct Expr(sys::expr);
+
+//======================================
+// Expression wrapper types
+//======================================
+
+/// Generate all the common methods for an expression wrapper type.
+macro_rules! expr_wrapper {
+    (
+        $(#[$outer:meta])* struct $name:ident,
+        $predicate:ident
+    ) => {
+        // TODO: Provide a better Debug implementation for these types
+        #[derive(Debug)]
+        $(#[$outer])*
+        #[derive(ref_cast::RefCastCustom)]
+        #[repr(transparent)]
+        pub struct $name(Expr);
+
+        /// General expression wrapper type methods.
+        impl $name {
+            /// Attempt to convert `expr` into `Self`.
+            #[inline(always)]
+            pub fn try_from_expr(expr: Expr) -> Option<Self> {
+                if predicates::$predicate(&expr) {
+                    Some(unsafe { $name::unchecked_from_expr(expr) })
+                } else {
+                    None
+                }
+            }
+
+            /// Attempt to convert `expr` into `&Self`.
+            #[inline(always)]
+            pub fn try_from_expr_ref(expr: &Expr) -> Option<&Self> {
+                if predicates::$predicate(&expr) {
+                    Some(unsafe { $name::unchecked_from_expr_ref(expr) })
+                } else {
+                    None
+                }
+            }
+
+            /// Private.
+            ///
+            /// Unsafely interpret an [`Expr`] as an instance of this expression wrapper
+            /// type.
+            ///
+            /// Strongly prefer using [`try_from_expr()`][Self::try_from_expr()] instead
+            /// of this method.
+            ///
+            /// # Safety
+            ///
+            /// `expr` must satisfy the predicate associated with this expression wrapper
+            /// type.
+            #[inline]
+            pub(crate) unsafe fn unchecked_from_expr(expr: Expr) -> Self {
+                debug_assert!(predicates::$predicate(&expr));
+
+                $name(expr)
+            }
+
+            /// # Safety
+            ///
+            /// `expr` must satisfy the predicate associated with this expression wrapper
+            /// type.
+            #[inline]
+            #[ref_cast::ref_cast_custom]
+            pub(crate) unsafe fn unchecked_from_expr_ref(expr: &Expr) -> &Self;
+
+            // #[allow(dead_code)]
+            // pub(in crate::expr) unsafe fn unchecked_from_expr_ref_mut(expr: &mut Expr) -> &mut Self {
+            //     debug_assert!(predicates::$predicate(expr));
+
+            //     expr_ref_cast_mut::<Expr, Self>(expr)
+            // }
+
+            /// Get a reference to the underlying [`Expr`] this type wraps.
+            pub fn as_expr(&self) -> &Expr {
+                let $name(e) = self;
+                e
+            }
+
+            #[allow(dead_code)]
+            pub(crate) fn as_expr_mut(&mut self) -> &mut Expr {
+                let $name(e) = self;
+                e
+            }
+
+            /// Get the underlying [`Expr`] this type wraps.
+            pub fn into_expr(self) -> Expr {
+                let $name(e) = self;
+                e
+            }
+        }
+
+        impl AsRef<Expr> for $name {
+            fn as_ref(&self) -> &Expr {
+                $name::as_expr(self)
+            }
+        }
+
+        impl From<$name> for Expr {
+            fn from(e: $name) -> Expr {
+                $name::into_expr(e)
+            }
+        }
+    };
+}
+
+expr_wrapper![
+    /// Machine integer expression wrapper.
+    ///
+    /// This type represents an expression which has been validated to be a
+    /// machine integer.
+    ///
+    /// Use [`MIntExpr::as_expr()`] and [`MIntExpr::into_expr()`] to access the underlying
+    /// [`Expr`].
+    struct MIntExpr,
+    MIntegerQ
+];
+
+expr_wrapper![
+    /// Machine real expression wrapper.
+    ///
+    /// This type represents an expression which has been validated to be a
+    /// machine real.
+    ///
+    /// Use [`MRealExpr::as_expr()`] and [`MRealExpr::into_expr()`] to access the underlying
+    /// [`Expr`].
+    struct MRealExpr,
+    MRealQ
+];
+
+expr_wrapper![
+    /// Normal expression wrapper.
+    ///
+    /// This type represents an expression which has been validated to be a Normal.
+    ///
+    /// Use [`NormalExpr::as_expr()`] and [`NormalExpr::into_expr()`] to access the underlying
+    /// [`Expr`].
+    struct NormalExpr,
+    NormalQ
+];
+
+expr_wrapper![
+    /// Symbol expression wrapper.
+    ///
+    /// This type represents an expression which has been validated to be a Symbol.
+    ///
+    /// Use [`SymbolExpr::as_expr()`] and [`SymbolExpr::into_expr()`] to access the underlying
+    /// [`Expr`].
+    struct SymbolExpr,
+    SymbolQ
+];
+
+expr_wrapper![
+    /// String expression wrapper.
+    ///
+    /// This type represents an expression which has been validated to be a String.
+    ///
+    /// The `E` prefix distinguishes this type from the standard library [`String`] type.
+    ///
+    /// Use [`StringExpr::as_expr()`] and [`StringExpr::into_expr()`] to access the underlying
+    /// [`Expr`].
+    struct StringExpr,
+    StringQ
+];
+
+//======================================
+// Impl Expr
+//======================================
+
+impl Expr {
+    /// # Panics
+    ///
+    /// Panics if `expr` is not a success result.
+    pub(crate) unsafe fn from_result(expr: sys::expr) -> Expr {
+        Expr::try_from_result(expr).expect("Got EFAIL or ENULL")
+    }
+
+    pub(crate) unsafe fn try_from_result(expr: sys::expr) -> Option<Expr> {
+        unsafe {
+            if expr == sys::LoadEFAIL() || expr == sys::LoadENULL() {
+                return None;
+            }
+        }
+
+        Some(Expr(expr))
+    }
+
+    /// Take ownership of `self` and return the underyling expression pointer.
+    #[allow(dead_code)]
+    pub(crate) unsafe fn into_c_expr(self) -> sys::expr {
+        let Expr(e) = self;
+
+        // Don't drop `self` if it's going to be used as a raw `expr`.
+        // Note: We have to explicitly forget `self` because the move of `e` above is
+        //       actually a copy; `self` is still valid even though it appears we moved
+        //       ownership out of it.
+        std::mem::forget(self);
+
+        e
+    }
+
+    /// Access the C [`expr`][sys::expr] type wrapped by this `Expr`.
+    ///
+    /// This function returns what is conceptually a *borrowed* `expr`.
+    ///
+    /// If you need an owned, counted copy of the C expr, use [`Expr::into_c_expr()`].
+    #[inline(always)]
+    pub(crate) unsafe fn to_c_expr(&self) -> sys::expr {
+        let Expr(inner) = *self;
+
+        inner
+    }
+}
+
+//======================================
+// Drop Impls
+//======================================
+
+impl Drop for Expr {
+    fn drop(&mut self) {
+        let Expr(expr) = self;
+
+        let expr: &mut sys::expr = expr;
+
+        unsafe {
+            sys::Runtime_DecrementRefCount(expr);
+        }
+    }
+}

--- a/wolfram-library-link/src/kernel/predicates.rs
+++ b/wolfram-library-link/src/kernel/predicates.rs
@@ -1,0 +1,42 @@
+#![allow(non_snake_case)]
+
+use crate::kernel::Expr;
+
+/// A type value only uses the first 4 bits.
+const TYPE_MASK: u16 = 0b1111;
+
+mod expr_type {
+    pub const MACHINE_INTEGER: u16 = 0;
+    pub const MACHINE_REAL: u16 = 2;
+
+    pub const NORMAL: u16 = 6;
+    pub const SYMBOL: u16 = 7;
+    pub const STRING: u16 = 8;
+}
+
+impl Expr {
+    #[inline]
+    pub(crate) fn type_flags(&self) -> u16 {
+        self.flags() & TYPE_MASK
+    }
+}
+
+pub(crate) fn MIntegerQ(expr: &Expr) -> bool {
+    expr.type_flags() == expr_type::MACHINE_INTEGER
+}
+
+pub(crate) fn MRealQ(expr: &Expr) -> bool {
+    expr.type_flags() == expr_type::MACHINE_REAL
+}
+
+pub(crate) fn NormalQ(expr: &Expr) -> bool {
+    expr.type_flags() == expr_type::NORMAL
+}
+
+pub(crate) fn SymbolQ(expr: &Expr) -> bool {
+    expr.type_flags() == expr_type::SYMBOL
+}
+
+pub(crate) fn StringQ(expr: &Expr) -> bool {
+    expr.type_flags() == expr_type::STRING
+}

--- a/wolfram-library-link/src/kernel/sys.rs
+++ b/wolfram-library-link/src/kernel/sys.rs
@@ -37,4 +37,5 @@ extern "C" {
     pub(crate) fn Runtime_DecrementRefCount(e: *mut expr) -> mint;
     pub(crate) fn Flags_Expression_UnsignedInteger16(arg: expr) -> u16;
     pub(crate) fn UTF8BytesToStringExpression(data: *const c_uchar, len: mint) -> expr;
+    pub(crate) fn Evaluate_E_E(arg: expr) -> expr;
 }

--- a/wolfram-library-link/src/kernel/sys.rs
+++ b/wolfram-library-link/src/kernel/sys.rs
@@ -1,0 +1,39 @@
+#![allow(non_camel_case_types)]
+
+use std::{
+    ffi::c_uchar,
+    marker::{PhantomData, PhantomPinned},
+};
+
+#[repr(C)]
+pub struct expr_struct {
+    _data: [u8; 0],
+    // Prevent this type from being auto Send, Sync, or Pin.
+    _marker: PhantomData<(*mut u8, PhantomPinned)>,
+}
+
+pub(crate) type expr = *mut expr_struct;
+
+pub(crate) type mint = isize;
+
+//
+// Type declarations available from compiler type system setup code for
+// Native`PrimitiveFunction values, in:
+//
+// $InstallationDirectory/SystemFiles/Components/Compile/TypeSystem/Declarations/
+//
+
+#[rustfmt::skip]
+extern "C" {
+    pub(crate) fn Print_E_I(arg: expr) -> mint;
+    pub(crate) fn CreateMIntegerExpr(i: i64, size: u32, signedQ: bool) -> expr;
+    pub(crate) fn LookupSymbol_E_E(arg: expr) -> expr;
+    pub(crate) fn SetSymbol_E_E_E(arg1: expr, arg2: expr) -> expr;
+    pub(crate) fn CreateHeaded_IE_E(len: mint, head: expr) -> expr;
+    pub(crate) fn SetElement_EIE_E(base_arg: expr, pos: mint, elem_arg: expr);
+    pub(crate) fn LoadEFAIL() -> expr;
+    pub(crate) fn LoadENULL() -> expr;
+    pub(crate) fn Runtime_DecrementRefCount(e: *mut expr) -> mint;
+    pub(crate) fn Flags_Expression_UnsignedInteger16(arg: expr) -> u16;
+    pub(crate) fn UTF8BytesToStringExpression(data: *const c_uchar, len: mint) -> expr;
+}

--- a/wolfram-library-link/src/kernel/sys.rs
+++ b/wolfram-library-link/src/kernel/sys.rs
@@ -1,9 +1,11 @@
 #![allow(non_camel_case_types)]
 
 use std::{
-    ffi::c_uchar,
+    ffi::{c_uchar, c_void},
     marker::{PhantomData, PhantomPinned},
 };
+
+use wolfram_library_link_sys::mint;
 
 #[repr(C)]
 pub struct expr_struct {
@@ -13,8 +15,6 @@ pub struct expr_struct {
 }
 
 pub(crate) type expr = *mut expr_struct;
-
-pub(crate) type mint = isize;
 
 //
 // Type declarations available from compiler type system setup code for
@@ -27,6 +27,7 @@ pub(crate) type mint = isize;
 extern "C" {
     pub(crate) fn Print_E_I(arg: expr) -> mint;
     pub(crate) fn CreateMIntegerExpr(i: i64, size: u32, signedQ: bool) -> expr;
+    pub(crate) fn CreateMRealExpr(src: *mut c_void, size: u32) -> expr;
     pub(crate) fn LookupSymbol_E_E(arg: expr) -> expr;
     pub(crate) fn SetSymbol_E_E_E(arg1: expr, arg2: expr) -> expr;
     pub(crate) fn CreateHeaded_IE_E(len: mint, head: expr) -> expr;

--- a/wolfram-library-link/src/kernel/sys.rs
+++ b/wolfram-library-link/src/kernel/sys.rs
@@ -30,6 +30,7 @@ extern "C" {
     pub(crate) fn CreateMRealExpr(src: *mut c_void, size: u32) -> expr;
     pub(crate) fn LookupSymbol_E_E(arg: expr) -> expr;
     pub(crate) fn SetSymbol_E_E_E(arg1: expr, arg2: expr) -> expr;
+    pub(crate) fn SetSymbolDownCode(a1: expr, a2: *mut c_void);
     pub(crate) fn CreateHeaded_IE_E(len: mint, head: expr) -> expr;
     pub(crate) fn SetElement_EIE_E(base_arg: expr, pos: mint, elem_arg: expr);
     pub(crate) fn LoadEFAIL() -> expr;

--- a/wolfram-library-link/src/lib.rs
+++ b/wolfram-library-link/src/lib.rs
@@ -237,6 +237,14 @@ pub mod rtl;
 
 pub mod docs;
 
+// Hide this module unless the `experimental-kernel-expr` feature is enabled.
+//
+// To view this documentation locally, build with:
+//
+//     cargo doc --features experimental-kernel-expr
+#[cfg_attr(not(feature = "experimental-kernel-expr"), doc(hidden))]
+pub mod kernel;
+
 
 // Note: This is exported as doc(inline) so that it shows up in the 'Modules' section of
 //       the crate docs instead of in the 'Re-exports' section. This is to make way for


### PR DESCRIPTION
This functionality is highly experimental, and is not included in the public wolfram-library-link documentation for the time being.

To experiment with this functionality, the documentation that is available can be viewed locally by running:

    $ cargo doc --open --features experimental-kernel-expr